### PR TITLE
Remove Mega.nz

### DIFF
--- a/file-hosting
+++ b/file-hosting
@@ -7,7 +7,6 @@ hugefiles.cc
 hugefiles.net
 jetload.net
 mediafire.com
-mega.nz
 mixdrop.co
 netu.best
 nitroflare.com


### PR DESCRIPTION
Many people use Mega for genuine file sharing purposes. Adding it to this list would be doing an injustice.