### PR TITLE
Remove false positive Academic Torrents

### DIFF
--- a/torrent-websites
+++ b/torrent-websites
@@ -42,7 +42,6 @@
 8wsm.com
 9anime.to
 a8bt.com
-academictorrents.com
 acg.rip
 acglover.top
 acgnx.se


### PR DESCRIPTION
Hello,

The platform Academic Torrents is a 501(c)3 non-profit working to facilitate the distribution of scientific data. The platform does not allow piracy and should not be included in a list of piracy sites. Only educational and approved accounts are allow to upload torrent files.

-Joseph 